### PR TITLE
Outgoing logging interceptor

### DIFF
--- a/backend/src/main/kotlin/rocks/didit/sefilm/Application.kt
+++ b/backend/src/main/kotlin/rocks/didit/sefilm/Application.kt
@@ -22,6 +22,7 @@ import org.springframework.core.io.ClassPathResource
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.http.client.BufferingClientHttpRequestFactory
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
 import org.springframework.scheduling.annotation.EnableAsync
@@ -39,6 +40,7 @@ import rocks.didit.sefilm.database.repositories.ShowingRepository
 import rocks.didit.sefilm.domain.Base64ID
 import rocks.didit.sefilm.domain.ExternalProviderErrorHandler
 import rocks.didit.sefilm.graphql.GraphqlExceptionHandler
+import rocks.didit.sefilm.logging.OutgoingLoggingInterceptor
 import rocks.didit.sefilm.notification.MailSettings
 import rocks.didit.sefilm.notification.PushoverSettings
 import rocks.didit.sefilm.services.SlugService
@@ -68,13 +70,19 @@ class Application {
   }
 
   @Bean
-  fun httpRequestFactory(httpClient: HttpClient) = HttpComponentsClientHttpRequestFactory(httpClient)
+  fun httpComponentsClientHttpRequestFactory(httpClient: HttpClient) =
+    HttpComponentsClientHttpRequestFactory(httpClient)
+
+  @Bean
+  fun requestFactory(clientHttpRequestFactory: HttpComponentsClientHttpRequestFactory) =
+    BufferingClientHttpRequestFactory(clientHttpRequestFactory)
 
   @Bean
   @Primary
-  fun getRestClient(requestFactory: HttpComponentsClientHttpRequestFactory): RestTemplate {
+  fun getRestClient(requestFactory: BufferingClientHttpRequestFactory): RestTemplate {
     val restClient = RestTemplate(requestFactory)
     restClient.errorHandler = ExternalProviderErrorHandler()
+    restClient.interceptors.add(OutgoingLoggingInterceptor())
     return restClient
   }
 

--- a/backend/src/main/kotlin/rocks/didit/sefilm/logging/OutgoingLoggingInterceptor.kt
+++ b/backend/src/main/kotlin/rocks/didit/sefilm/logging/OutgoingLoggingInterceptor.kt
@@ -1,0 +1,63 @@
+package rocks.didit.sefilm.logging
+
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpRequest
+import org.springframework.http.client.ClientHttpRequestExecution
+import org.springframework.http.client.ClientHttpRequestInterceptor
+import org.springframework.http.client.ClientHttpResponse
+import rocks.didit.sefilm.logger
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicLong
+
+class OutgoingLoggingInterceptor : ClientHttpRequestInterceptor {
+  private val logger by logger()
+  private val counter = AtomicLong(0)
+
+  override fun intercept(request: HttpRequest, body: ByteArray, execution: ClientHttpRequestExecution): ClientHttpResponse {
+    val currentCount = counter.getAndIncrement()
+    logRequest(request, body, currentCount)
+    val startRequestTime = Instant.now()
+    val response = execution.execute(request, body)
+    logResponse(response, currentCount, startRequestTime)
+    return response
+  }
+
+  private fun logRequest(request: HttpRequest, body: ByteArray, currentCount: Long) {
+    if (!logger.isDebugEnabled) {
+      return
+    }
+
+    logger.debug("\n$currentCount > ${request.method} ${request.uri}" +
+      "\n${assembleHeadersWithPrependedCounter(request.headers, currentCount)}" +
+      "\n${currentCount} > ${String(body, Charsets.UTF_8)}")
+  }
+
+  private fun assembleHeadersWithPrependedCounter(headers: HttpHeaders, counter: Long, separator: String = ">"): String {
+    return headers
+      .map { "$counter $separator ${it.key}: ${it.value.joinToString(",")}" }
+      .joinToString("\n")
+  }
+
+  private fun logResponse(response: ClientHttpResponse, currentCount: Long, startRequestTime: Instant) {
+    if (!logger.isDebugEnabled) {
+      return
+    }
+    val requestDuration = Duration.between(startRequestTime, Instant.now())
+    val inputStringBuilder = StringBuilder()
+    val bufferedReader = BufferedReader(InputStreamReader(response.body, Charsets.UTF_8))
+    var line: String? = bufferedReader.readLine()
+    while (line != null) {
+      inputStringBuilder.append(line)
+      inputStringBuilder.append('\n')
+      line = bufferedReader.readLine()
+    }
+    logger.debug("Request processed in ${requestDuration.toMillis()} ms" +
+      "\n$currentCount < ${response.rawStatusCode}" +
+      "\n${assembleHeadersWithPrependedCounter(response.headers, currentCount, "<")}" +
+      "\n${currentCount} < ${inputStringBuilder.toString()}")
+  }
+
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -70,3 +70,4 @@ graphql:
 logging:
   level:
     rocks.didit: ${logLevel:INFO}
+    rocks.didit.sefilm.logging: INFO


### PR DESCRIPTION
Looks something like this:
2019-08-23 21:03:53.937 DEBUG 28274 --- [   scheduling-1] r.d.s.l.RestTemplateLoggingInterceptor   :
462 > GET https://www.filmstaden.se/api/v2/show/sv/1/200?filter.countryAlias=se&filter.cityAlias=GB&filter.movieNcgId=NCG991513&filter.timeUtc.greaterThanOrEqualTo=2019-08-23T19:00
462 > Accept: application/json;charset=UTF-8
462 > User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36
462 > Content-Length: 0
462 >
2019-08-23 21:03:54.147 DEBUG 28274 --- [   scheduling-1] r.d.s.l.RestTemplateLoggingInterceptor   : Request, response processed in 209 ms
462 < 200
462 < Date: Fri, 23 Aug 2019 19:03:54 GMT
462 < Content-Type: application/json; charset=utf-8
462 < Connection: keep-alive
462 < Cache-Control: no-cache
462 < Pragma: no-cache
462 < Expires: -1
462 < Vary: Accept-Encoding
462 < X-PublicWeb-Version: 1.0.4504.7
462 < Suppress-Redirect: True
462 < X-AspNet-Version: 4.0.30319
462 < Request-Context: appId=cid-v1:466df248-5310-444e-8c19-8d2899fe4df6
462 < X-Powered-By: ASP.NET
462 < Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
462 < Server: cloudflare
462 < CF-RAY: 50af59622c6c3cab-CPH
462 < {"totalNbrOfItems":0,"items":[]}